### PR TITLE
Prepare v0.5.8 for HACS (version bump + README polish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,81 @@
-# Wrist Assistant - Home Assistant Integration
+# Wrist Assistant for Home Assistant
 
-Custom integration for [Home Assistant](https://www.home-assistant.io/) that adds a high-performance delta-sync API endpoint used by the [Wrist Assistant](https://github.com/NylonDiamond/ha-watch) Apple Watch app.
+Official Home Assistant integration for the [Wrist Assistant](https://github.com/NylonDiamond/ha-watch) Apple Watch app.
 
-## What it does
+Wrist Assistant adds fast delta-sync updates and a built-in QR pairing flow, so watch users can connect quickly and receive near real-time state changes without repeatedly downloading full entity state.
 
-This integration registers a single authenticated HTTP endpoint (`POST /api/watch/updates`) that provides near-real-time entity state updates to the watch app via long-polling. Instead of fetching all entity states on every poll, the watch sends a cursor and receives only the changes since that cursor — dramatically reducing bandwidth and latency.
+## Why install this
 
-### Key features
+- Faster watch updates with lower bandwidth usage (delta sync + long-poll)
+- Built-in QR pairing in Home Assistant (no manual token copy/paste)
+- Support for multiple watches with independent subscriptions
+- Recovery helpers for stale cursors and forced resync
+- Bounded memory event buffer for stable runtime behavior
 
-- **Long-poll delta sync** — the watch holds a connection open for up to 55 seconds, receiving updates the instant they happen
-- **Per-watch session tracking** — multiple watches can connect simultaneously, each with their own entity subscriptions
-- **Automatic cursor management** — stale cursors trigger a resync signal so the watch can recover gracefully
-- **Bounded memory** — uses a fixed-size ring buffer (5,000 events) so memory usage stays constant
-- **Ready-to-scan pairing QR** — generated automatically after setup, with refresh controls in the integration device
+## Install
 
-## Installation
+### HACS default store (once listed)
 
-### HACS (recommended)
+1. Open HACS -> Integrations.
+2. Search for `Wrist Assistant`.
+3. Install and restart Home Assistant.
+4. Go to Settings -> Devices & Services -> Add Integration -> `Wrist Assistant`.
 
-1. Open HACS in your Home Assistant UI
-2. Go to **Integrations**
-3. Click the three dots menu (top right) and select **Custom repositories**
-4. Add this repository URL: `https://github.com/NylonDiamond/homeassistant-wrist-assistant`
-5. Select category: **Integration**
-6. Click **Add**, then find "Wrist Assistant" in the integration list and install it
-7. Restart Home Assistant
-8. Go to **Settings** → **Devices & Services** → **Add Integration** → search for **Wrist Assistant**
+### HACS custom repository (while waiting for default listing)
+
+1. Open HACS -> Integrations.
+2. Open the 3-dot menu -> Custom repositories.
+3. Add `https://github.com/NylonDiamond/homeassistant-wrist-assistant`.
+4. Category: `Integration`.
+5. Install `Wrist Assistant` and restart Home Assistant.
+6. Go to Settings -> Devices & Services -> Add Integration -> `Wrist Assistant`.
 
 ### Manual
 
-1. Copy the `custom_components/wrist_assistant` directory to your Home Assistant `<config>/custom_components/` directory
-2. Restart Home Assistant
-3. Go to **Settings** → **Devices & Services** → **Add Integration** → search for **Wrist Assistant**
+1. Copy `custom_components/wrist_assistant` into `<config>/custom_components/`.
+2. Restart Home Assistant.
+3. Go to Settings -> Devices & Services -> Add Integration -> `Wrist Assistant`.
 
-## API Reference
+## First-time setup (about 1 minute)
+
+1. Install and add the integration.
+2. Open the persistent notification: `Wrist Assistant pairing ready`.
+3. In the watch app, open Sign in -> Scan QR.
+4. Scan the QR shown in Home Assistant.
+5. In the watch app settings, choose update mode `Auto` or `Delta`.
+
+## What you get in Home Assistant
+
+- `camera` entity: Pairing QR
+- `button` entity: Refresh pairing QR
+- `sensor` entity: Pairing expires at
+- Per-watch diagnostic entities (activity, subscriptions, poll interval, sync status, and naming)
+- Services: `wrist_assistant.create_pairing_code`, `wrist_assistant.force_resync`
+
+## Screenshots and GIFs
+
+Visual setup guide coming soon (integration card, pairing QR flow, and watch sync in action).
+
+## Troubleshooting
+
+- No pairing QR visible: Open the Wrist Assistant device page and press `Refresh pairing QR`. If still missing, restart Home Assistant and reopen the device page.
+- Watch reports out-of-sync data: Run `wrist_assistant.force_resync` and let the watch reconnect.
+- Pairing code expired: Press `Refresh pairing QR` or call `wrist_assistant.create_pairing_code` to generate a fresh code.
+
+## Security notes
+
+- Pairing codes are one-time and short-lived.
+- Redeeming a pairing code creates a long-lived access token.
+- Token lifespan is configurable with `lifespan_days` in `wrist_assistant.create_pairing_code`.
+- Delta sync endpoint requires authentication with a Home Assistant token.
+
+## Advanced API reference
 
 ### `POST /api/watch/updates`
 
-Authenticated long-poll endpoint. Requires a valid Home Assistant long-lived access token in the `Authorization` header.
+Authenticated long-poll endpoint for watch delta updates.
 
-#### Request body
+Example request body:
 
 ```json
 {
@@ -54,48 +90,23 @@ Authenticated long-poll endpoint. Requires a valid Home Assistant long-lived acc
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `watch_id` | string | yes | Unique identifier for this watch |
-| `config_hash` | string | yes | Hash of the current watch configuration — triggers entity re-sync when changed |
-| `since` | string | no | Cursor from previous response. Omit on first request |
-| `entities` | string[] | no | List of entity IDs to subscribe to. Send when config changes; omit on subsequent polls |
-| `timeout` | integer | no | Long-poll timeout in seconds (default 45, clamped to 5–55) |
+| `config_hash` | string | yes | Hash of current watch configuration; changed hash triggers re-subscribe |
+| `since` | string | no | Cursor from previous response; omit on first request |
+| `entities` | string[] | no | Entity IDs to subscribe to; send when config changes |
+| `timeout` | integer | no | Long-poll timeout in seconds (default 45, clamped to 5-55) |
 
-#### Responses
+Response behavior:
 
-**`200`** — Delta events available:
-
-```json
-{
-  "events": [
-    {
-      "entity_id": "light.kitchen",
-      "state": "on",
-      "new_state": {
-        "entity_id": "light.kitchen",
-        "state": "on",
-        "attributes": { "brightness": 128 },
-        "last_updated": "2026-02-09T22:11:01.123456+00:00"
-      },
-      "context_id": "01J....",
-      "last_updated": "2026-02-09T22:11:01.123456+00:00"
-    }
-  ],
-  "next_cursor": "124",
-  "need_entities": false,
-  "resync_required": false
-}
-```
-
-**`204`** — No changes within the timeout period.
-
-**`410`** — Cursor is stale or invalid. Client should perform a full state refresh and start with a fresh cursor.
-
-**`200` with `need_entities: true`** — Server needs the entity list. Client should resend the request with the `entities` array populated.
+- `200`: Delta events returned with `next_cursor`
+- `204`: No changes within timeout
+- `410`: Cursor stale/invalid; client should do full refresh and restart cursor
+- `200` with `need_entities: true`: resend request with `entities`
 
 ### `POST /api/wrist_assistant/pairing/redeem`
 
-Unauthenticated one-time code redemption endpoint used by QR setup flow.
+Unauthenticated one-time code redemption endpoint used by QR pairing.
 
-#### Request body
+Example request body:
 
 ```json
 {
@@ -103,7 +114,7 @@ Unauthenticated one-time code redemption endpoint used by QR setup flow.
 }
 ```
 
-#### Response body
+Example response body:
 
 ```json
 {
@@ -119,32 +130,19 @@ Unauthenticated one-time code redemption endpoint used by QR setup flow.
 
 ### `wrist_assistant.create_pairing_code` service
 
-Creates a short-lived one-time pairing code and returns a payload suitable for QR generation.
+Generates a short-lived one-time pairing code and returns a payload with `pairing_uri`.
 
-#### Service response fields
+Key response fields:
 
-- `pairing_code` — one-time code (expires in 10 minutes)
-- `pairing_uri` — payload to encode as QR, e.g. `wristassistant://pair?...`
-- `expires_at` — UTC expiration timestamp
-- `lifespan_days` — long-lived token lifespan (default 3650 days)
-- `home_assistant_url` / `local_url` / `remote_url` — URLs included in pairing payload
+- `pairing_code`: one-time code
+- `pairing_uri`: payload to encode as QR (`wristassistant://pair?...`)
+- `expires_at`: UTC expiration timestamp
+- `lifespan_days`: token lifespan (default 3650)
+- `home_assistant_url`, `local_url`, `remote_url`: URLs included in pairing payload
 
-Use this from **Developer Tools -> Actions**, then encode `pairing_uri` as a QR code and scan it from Wrist Assistant's **Sign in -> Scan QR** path.
+## Release process
 
-## Pairing UX (no Developer Tools required)
-
-After integration setup, Wrist Assistant now:
-
-- shows an immediate persistent notification with a scannable pairing QR image
-- exposes a `camera` entity **Pairing QR**
-- exposes a `button` entity **Refresh pairing QR**
-- exposes a sensor **Pairing expires at**
-
-So users can scan directly from the setup notification or integration device page.
-
-## Wrist Assistant App
-
-This integration is the server-side component for [Wrist Assistant](https://github.com/NylonDiamond/ha-watch), an Apple Watch app for controlling Home Assistant entities. In the watch app settings, set the update mode to **Auto** or **Delta** to use this endpoint.
+For each GitHub release, use `/RELEASE_NOTES_TEMPLATE.md` to write user-facing notes for HACS.
 
 ## License
 

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,71 @@
+# Release Notes Template (HACS + GitHub)
+
+Use this for each GitHub release. HACS users read this before updating.
+
+## Before writing
+
+1. Find previous tag: `git tag --sort=-creatordate | head -n 2`
+2. Gather commits: `git log --oneline <previous_tag>..HEAD`
+3. Keep only user-visible changes; skip noise/temporary commits.
+
+## Title
+
+`Wrist Assistant vX.Y.Z`
+
+## Quick summary (one line)
+
+- 
+
+## Highlights
+
+- 
+
+## Added
+
+- New capabilities users can see or use (for example: new entities, services, pairing UX improvements).
+
+## Changed
+
+- Behavior updates that are not fixes (for example: URL discovery logic, setup flow adjustments).
+
+## Fixed
+
+- Bug fixes (for example: stale cursor handling, QR refresh behavior, async/runtime issues).
+
+## Pairing and onboarding
+
+- QR pairing flow updates, token handling, URL fields, notification behavior.
+
+## Watch sync and reliability
+
+- Delta sync stability, 204/410 handling, session lifecycle, reconnect behavior.
+
+## Diagnostics and observability
+
+- Sensor/entity diagnostics, per-watch visibility, troubleshooting helpers.
+
+## Internal and maintenance (optional)
+
+- Validation/workflow/refactor work that may matter to advanced users.
+
+## Breaking changes
+
+- None.
+
+## Upgrade steps
+
+1. Update in HACS.
+2. Restart Home Assistant.
+3. Open Wrist Assistant on the watch and let it reconnect.
+4. If sync appears stale, run `wrist_assistant.force_resync`.
+
+## Known issues (optional)
+
+- 
+
+## Maintainer checklist
+
+- Mention if Home Assistant minimum version changed.
+- Mention if users need to re-pair.
+- Mention if any service/entity names changed.
+- Keep final notes concise (usually 5-12 bullets total).

--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["segno==1.6.6"],
-  "version": "0.5.7"
+  "version": "0.5.8"
 }


### PR DESCRIPTION
## Summary
- bump integration version to `0.5.8` in `custom_components/wrist_assistant/manifest.json`
- improve README for HACS first-time onboarding and troubleshooting
- add a reusable release notes template for future GitHub/HACS releases

## Why
- prepare the next HACS-visible release with cleaner user-facing docs
- keep release communication consistent for updates

## Validation
- manifest key order remains Hassfest-compliant
- no runtime code-path changes in this PR (metadata/docs only)
