### PR TITLE
Release v0.5.10 (correct tag for QR notification fix)

### DIFF
--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["segno==1.6.6"],
-  "version": "0.5.9"
+  "version": "0.5.10"
 }


### PR DESCRIPTION
## Summary
- bump integration manifest version to `0.5.10`

## Why
- correct release sequencing so HACS can pick up the QR notification fix that is already on `main`
- previous `v0.5.9` tag points to the pre-fix commit
