### PR TITLE
Disable noisy entities, fix watch disconnect states

### DIFF
--- a/custom_components/wrist_assistant/binary_sensor.py
+++ b/custom_components/wrist_assistant/binary_sensor.py
@@ -90,18 +90,18 @@ class WatchSyncStatusSensor(BinarySensorEntity):
 
     @property
     def available(self) -> bool:
-        return self._watch_id in self._coordinator._sessions
+        return True
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         session = self._coordinator._sessions.get(self._watch_id)
         if session is None:
-            return None
+            return False
         return session.entities_synced
 
     @property
     def extra_state_attributes(self) -> dict:
         session = self._coordinator._sessions.get(self._watch_id)
         if session is None:
-            return {}
+            return {"config_hash": None}
         return {"config_hash": session.config_hash}

--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["segno==1.6.6"],
-  "version": "0.6.0"
+  "version": "0.6.1"
 }


### PR DESCRIPTION
## Summary
- Disable by default: event buffer usage, events per minute, events processed, pairing expires at, poll interval
- Fix watch disconnect so entities don't all go "unknown" — last activity and subscribed entities cache their values, sync status shows "Disconnected", connected since goes unavailable
- Bump version to 0.6.1

## Test plan
- [ ] Fresh install: disabled entities don't appear unless manually enabled
- [ ] Put watch app in background, wait for session to expire (~5 min)
- [ ] Last activity shows the last known timestamp (not unknown)
- [ ] Subscribed entities still shows count and entity list
- [ ] Sync status shows "Disconnected" (not unknown)
- [ ] Connected since shows "Unavailable"
- [ ] Reconnect watch — all entities update normally again

🤖 Generated with [Claude Code](https://claude.com/claude-code)