### PR TITLE
Force-disable noisy entities on upgrade, fix disconnect states

### DIFF
--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["segno==1.6.6"],
-  "version": "0.6.1"
+  "version": "0.6.2"
 }

--- a/custom_components/wrist_assistant/sensor.py
+++ b/custom_components/wrist_assistant/sensor.py
@@ -409,7 +409,6 @@ class WatchConnectedSinceSensor(_WatchSensorBase):
     """Timestamp of when this watch first connected in the current session."""
 
     _attr_name = "Connected since"
-    _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_icon = "mdi:connection"
 
     def __init__(
@@ -419,8 +418,12 @@ class WatchConnectedSinceSensor(_WatchSensorBase):
         self._attr_unique_id = f"wrist_assistant_{watch_id}_connected_since"
 
     @property
-    def native_value(self):
+    def available(self) -> bool:
+        return True
+
+    @property
+    def native_value(self) -> str | None:
         session = self._coordinator._sessions.get(self._watch_id)
         if session is None:
-            return None
-        return session.first_seen
+            return "N/A"
+        return session.first_seen.isoformat()


### PR DESCRIPTION
## Summary
- `entity_registry_enabled_default = False` only works for new installs — add `_disable_noisy_entities()` migration that programmatically disables existing entities on upgrade
- Change "Connected since" to show "N/A" when watch disconnects instead of going unavailable

## Test plan
- [ ] Upgrade from 0.6.1 — events processed, buffer usage, events/min, pairing expiry, poll interval should all become disabled
- [ ] Connected since shows "N/A" when watch goes to background
- [ ] Connected since shows timestamp when watch is connected
- [ ] Re-enabling a disabled entity in the UI works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)