### PR TITLE
Fix watch tokens revoked on every restart/update

### DIFF
--- a/custom_components/wrist_assistant/__init__.py
+++ b/custom_components/wrist_assistant/__init__.py
@@ -286,6 +286,9 @@ async def _cleanup_orphaned_pairing_tokens(
     orphaned long-lived tokens in the auth system. Identify them by
     client_id and client_name prefix, then revoke any that are not
     tracked by the current PairingCoordinator.
+
+    Only revoke tokens that were never redeemed (last_used_at is None).
+    Redeemed tokens have been issued to a watch app and must be kept.
     """
     active_token_ids = pairing.tracked_refresh_token_ids
     revoked = 0
@@ -296,6 +299,7 @@ async def _cleanup_orphaned_pairing_tokens(
                 and token.client_name
                 and token.client_name.startswith("Wrist Assistant QR Pairing")
                 and token.id not in active_token_ids
+                and token.last_used_at is None
             ):
                 hass.auth.async_remove_refresh_token(token)
                 revoked += 1

--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["segno==1.6.6"],
-  "version": "0.6.2"
+  "version": "0.6.3"
 }


### PR DESCRIPTION
## Summary
- **Bug**: The orphaned token cleanup ran on every startup with an empty PairingCoordinator, so it revoked ALL pairing tokens — including ones actively used by the watch app. This forced re-pairing after every HACS update or HA restart.
- **Fix**: Only revoke tokens where `last_used_at is None` (never redeemed). Redeemed tokens have `last_used_at` set during redemption and are now preserved.

## Test plan
- [ ] Update via HACS — watch app stays connected without re-pairing
- [ ] Restart HA — watch app stays connected
- [ ] Generate a pairing code but don't redeem it, restart HA — the unredeemed token is cleaned up
- [ ] Pair a new watch via QR — works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)