### PR TITLE
Fix Name unavailable on disconnect, disable Connected Since

### DIFF
--- a/custom_components/wrist_assistant/__init__.py
+++ b/custom_components/wrist_assistant/__init__.py
@@ -50,6 +50,7 @@ _DISABLE_ON_UPGRADE_SUFFIXES = (
     "_events_per_minute",
     "_pairing_expires_at",
     "_poll_interval",
+    "_connected_since",
 )
 _PAIRING_NOTIFICATION_ID_TEMPLATE = "wrist_assistant_pairing_%s"
 _CREATE_PAIRING_SCHEMA = vol.Schema(

--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["segno==1.6.6"],
-  "version": "0.6.3"
+  "version": "0.6.4"
 }

--- a/custom_components/wrist_assistant/sensor.py
+++ b/custom_components/wrist_assistant/sensor.py
@@ -410,6 +410,7 @@ class WatchConnectedSinceSensor(_WatchSensorBase):
 
     _attr_name = "Connected since"
     _attr_icon = "mdi:connection"
+    _attr_entity_registry_enabled_default = False
 
     def __init__(
         self, coordinator: DeltaCoordinator, entry: ConfigEntry, watch_id: str

--- a/custom_components/wrist_assistant/text.py
+++ b/custom_components/wrist_assistant/text.py
@@ -97,4 +97,4 @@ class WatchNameText(TextEntity):
 
     @property
     def available(self) -> bool:
-        return self._watch_id in self._coordinator._sessions
+        return True


### PR DESCRIPTION
## Summary
- Fix Name text entity showing "unavailable" when watch disconnects — it reads from device registry, not the session, so it should always be available
- Disable "Connected since" by default (new installs + upgrade migration)
- Bump version to 0.6.4

## Test plan
- [ ] Disconnect watch — Name still shows the device name, not "unavailable"
- [ ] Connected since is disabled after upgrade
- [ ] Name can still be edited when watch is disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)