### PR TITLE
Name pairing tokens after the redeeming device

### DIFF
--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["segno==1.6.6"],
-  "version": "0.6.4"
+  "version": "0.6.5"
 }


### PR DESCRIPTION
## Summary
- Accept optional `device_name` field in the `/api/wrist_assistant/pairing/redeem` request
- When provided, renames the refresh token from `Wrist Assistant QR Pairing OOgr0aXe` to `Wrist Assistant (Jesse's Apple Watch)`
- Backward compatible — older app versions that don't send `device_name` keep the existing random-suffix name
- Watch app sends `WKInterfaceDevice.current().name` automatically, no user input needed

## Test plan
- [ ] Redeem with `device_name` in body — token shows as "Wrist Assistant (device name)" in HA security page
- [ ] Redeem without `device_name` — old name format still works
- [ ] Token functions normally after rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)