### PR TITLE
Release v0.7.4 — Simplify README for public launch

### DIFF
--- a/.claude/skills/hacs-release/SKILL.md
+++ b/.claude/skills/hacs-release/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: hacs-release
+description: Bump version, create PR, merge, and publish a GitHub release so HACS can pick up the update.
+argument-hint: "[version e.g. 0.7.0]"
+disable-model-invocation: true
+---
+
+Create a full HACS release. The version argument is $ARGUMENTS (if not provided, auto-increment the patch version from manifest.json).
+
+## Steps
+
+1. **Determine version**: Use the provided version, or read `custom_components/wrist_assistant/manifest.json` and increment the patch number.
+2. **Check git status**: Ensure there are changes to release (staged, unstaged, or already committed on the branch ahead of main). If the working tree is clean and on main with nothing ahead, abort — there's nothing to release.
+3. **Bump version** in `custom_components/wrist_assistant/manifest.json`.
+4. **Create a branch** named after the release (e.g., `release/v0.7.0`).
+5. **Stage and commit** all changes (including the version bump) with a descriptive commit message. Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`.
+6. **Push** the branch with `-u`.
+7. **Create a PR** with a summary of changes and a test plan.
+8. **Merge the PR** with `gh pr merge --merge --admin`.
+9. **Pull main** so local is up to date.
+10. **Create a GitHub release** with `gh release create vX.Y.Z` including release notes summarizing the changes.
+11. **Report** the release URL to the user.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,35 @@
 # Wrist Assistant for Home Assistant
 
-Official Home Assistant integration for the [Wrist Assistant](https://github.com/NylonDiamond/ha-watch) Apple Watch app.
+**Coming soon:** The Wrist Assistant app is not released yet.
 
-Wrist Assistant adds fast delta-sync updates and a pairing code flow, so watch users can connect quickly and receive near real-time state changes without repeatedly downloading full entity state.
+Official Home Assistant integration for the [Wrist Assistant](https://apps.apple.com/us/search?term=Wrist%20Assistant) Apple Watch app (coming soon).
+
+The iOS app is currently going through Apple App Store review and release processes.
+
+Wrist Assistant gives you automatic, real-time two-way sync between Apple Watch and Home Assistant, with a setup experience that is fast, reliable, and hands-off.
 
 ## Why install this
 
-- Faster watch updates with lower bandwidth usage (delta sync + long-poll)
-- Built-in pairing code generation for easy watch setup
-- Support for multiple watches with independent subscriptions
-- Recovery helpers for stale cursors and forced resync
-- Bounded memory event buffer for stable runtime behavior
+- Fast watch updates for a snappy feel
+- Automatic watch pairing
+- Real-time two-way sync between your watch and Home Assistant
+- Multi-watch support for shared homes
+- Reliable background sync with minimal effort
 
 ## Install
 
-### HACS default store (once listed)
+### iOS app onboarding (recommended, coming soon)
+
+1. Install the Wrist Assistant iOS app.
+2. Go through the onboarding steps.
+3. The app installs and sets up the Home Assistant integration automatically for you.
+
+### HACS (available now)
 
 1. Open HACS -> Integrations.
 2. Search for `Wrist Assistant`.
 3. Install and restart Home Assistant.
 4. Go to Settings -> Devices & Services -> Add Integration -> `Wrist Assistant`.
-
-### HACS custom repository (while waiting for default listing)
-
-1. Open HACS -> Integrations.
-2. Open the 3-dot menu -> Custom repositories.
-3. Add `https://github.com/NylonDiamond/homeassistant-wrist-assistant`.
-4. Category: `Integration`.
-5. Install `Wrist Assistant` and restart Home Assistant.
-6. Go to Settings -> Devices & Services -> Add Integration -> `Wrist Assistant`.
 
 ### Manual
 
@@ -36,109 +37,15 @@ Wrist Assistant adds fast delta-sync updates and a pairing code flow, so watch u
 2. Restart Home Assistant.
 3. Go to Settings -> Devices & Services -> Add Integration -> `Wrist Assistant`.
 
-## First-time setup
-
-1. Install and add the integration.
-2. Call the `wrist_assistant.create_pairing_code` service to generate a pairing code.
-3. Enter the pairing code and connection details in the Wrist Assistant app.
-4. In the watch app settings, choose update mode `Auto` or `Delta`.
-
 ## What you get in Home Assistant
 
-- `sensor` entity: Pairing expires at
-- Per-watch diagnostic entities (activity, subscriptions, poll interval, sync status, and naming)
-- Services: `wrist_assistant.create_pairing_code`, `wrist_assistant.force_resync`
+- Automatic watch pairing during onboarding
+- Real-time two-way sync for fast state and control updates
+- Smooth multi-watch support for shared homes
 
 ## Screenshots and GIFs
 
 Visual setup guide coming soon (integration card, pairing flow, and watch sync in action).
-
-## Troubleshooting
-
-- Watch reports out-of-sync data: Run `wrist_assistant.force_resync` and let the watch reconnect.
-- Pairing code expired: Call `wrist_assistant.create_pairing_code` to generate a fresh code.
-
-## Security notes
-
-- Pairing codes are one-time and short-lived.
-- Redeeming a pairing code creates a long-lived access token.
-- Token lifespan is configurable with `lifespan_days` in `wrist_assistant.create_pairing_code`.
-- Delta sync endpoint requires authentication with a Home Assistant token.
-
-## Advanced API reference
-
-### `POST /api/watch/updates`
-
-Authenticated long-poll endpoint for watch delta updates.
-
-Example request body:
-
-```json
-{
-  "watch_id": "UUID",
-  "since": "123",
-  "config_hash": "f88e947d...",
-  "entities": ["light.kitchen", "switch.fan"],
-  "timeout": 45
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `watch_id` | string | yes | Unique identifier for this watch |
-| `config_hash` | string | yes | Hash of current watch configuration; changed hash triggers re-subscribe |
-| `since` | string | no | Cursor from previous response; omit on first request |
-| `entities` | string[] | no | Entity IDs to subscribe to; send when config changes |
-| `timeout` | integer | no | Long-poll timeout in seconds (default 45, clamped to 5-55) |
-
-Response behavior:
-
-- `200`: Delta events returned with `next_cursor`
-- `204`: No changes within timeout
-- `410`: Cursor stale/invalid; client should do full refresh and restart cursor
-- `200` with `need_entities: true`: resend request with `entities`
-
-### `POST /api/wrist_assistant/pairing/redeem`
-
-Unauthenticated one-time code redemption endpoint used by pairing.
-
-Example request body:
-
-```json
-{
-  "pairing_code": "kV2..."
-}
-```
-
-Example response body:
-
-```json
-{
-  "access_token": "eyJ...",
-  "token_type": "Bearer",
-  "auth_mode": "manual_token",
-  "expires_in": 315360000,
-  "home_assistant_url": "https://ha.example.com",
-  "local_url": "http://homeassistant.local:8123",
-  "remote_url": "https://ha.example.com"
-}
-```
-
-### `wrist_assistant.create_pairing_code` service
-
-Generates a short-lived one-time pairing code and returns a payload with connection details.
-
-Key response fields:
-
-- `pairing_code`: one-time code
-- `pairing_uri`: deep link (`wristassistant://pair?...`)
-- `expires_at`: UTC expiration timestamp
-- `lifespan_days`: token lifespan (default 3650)
-- `home_assistant_url`, `local_url`, `remote_url`: URLs included in pairing payload
-
-## Release process
-
-For each GitHub release, use `/RELEASE_NOTES_TEMPLATE.md` to write user-facing notes for HACS.
 
 ## License
 

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -26,27 +26,23 @@ Use this for each GitHub release. HACS users read this before updating.
 
 ## Changed
 
-- Behavior updates that are not fixes (for example: URL discovery logic, setup flow adjustments).
+- Behavior updates that are not fixes (for example: setup flow adjustments and quality-of-life improvements).
 
 ## Fixed
 
-- Bug fixes (for example: stale cursor handling, QR refresh behavior, async/runtime issues).
+- Bug fixes users can notice (for example: reconnect issues, setup friction, reliability problems).
 
-## Pairing and onboarding
+## Setup and onboarding
 
-- QR pairing flow updates, token handling, URL fields, notification behavior.
+- Pairing experience updates, setup clarity, and first-run improvements.
 
-## Watch sync and reliability
+## Watch experience and reliability
 
-- Delta sync stability, 204/410 handling, session lifecycle, reconnect behavior.
+- Responsiveness, consistency, reconnect behavior, and overall watch experience quality.
 
 ## Diagnostics and observability
 
 - Sensor/entity diagnostics, per-watch visibility, troubleshooting helpers.
-
-## Internal and maintenance (optional)
-
-- Validation/workflow/refactor work that may matter to advanced users.
 
 ## Breaking changes
 
@@ -67,5 +63,5 @@ Use this for each GitHub release. HACS users read this before updating.
 
 - Mention if Home Assistant minimum version changed.
 - Mention if users need to re-pair.
-- Mention if any service/entity names changed.
+- Mention if any user-facing names changed.
 - Keep final notes concise (usually 5-12 bullets total).

--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": [],
-  "version": "0.7.3"
+  "version": "0.7.4"
 }

--- a/futureIdeas/ha-api-alternatives-research.md
+++ b/futureIdeas/ha-api-alternatives-research.md
@@ -1,0 +1,85 @@
+# HA API Alternatives Research
+
+> Can the HACS integration be replaced by using Home Assistant's built-in APIs directly?
+>
+> **TL;DR: No.** The integration uniquely combines HTTP long-poll + server-side entity filtering + delta-only payloads + WatchOS compatibility. No combination of built-in HA APIs replicates all four on WatchOS.
+
+## 1. HA Built-in API Capabilities
+
+### WebSocket `subscribe_entities`
+- Server-side entity filtering via `entity_ids` parameter + compressed deltas (~80% bandwidth reduction).
+- Available since HA 2022.4.
+- The gold standard for real-time state updates — but requires WebSocket.
+
+### SSE `GET /api/stream`
+- Long-lived HTTP streaming (Server-Sent Events).
+- **No entity filtering** — only event type filtering via `?restrict=` query parameter.
+- Requires admin-level authentication.
+- Semi-deprecated: not documented in the official HA REST API docs.
+
+### `POST /api/template`
+- Single HTTP request, returns rendered Jinja2 template.
+- Can embed entity list + timestamps for delta detection client-side.
+- Zero HA config needed — works out of the box.
+- Polling only.
+
+### History API
+- `GET /api/history/period/<timestamp>?filter_entity_id=x,y&minimal_response`
+- True server-side time + entity filtering.
+- Queries the recorder database directly.
+- Polling only.
+
+### REST `GET /api/states/<entity_id>`
+- Per-entity polling. N requests for N entities.
+- Simplest approach but worst scaling.
+
+## 2. WatchOS Platform Restrictions
+
+**WebSocket is completely blocked on WatchOS 9+ (September 2022).**
+
+This is not a reliability issue — it is a hard platform restriction. Both `URLSessionWebSocketTask` and `NWConnection` WebSocket produce `Error: Operation not supported by device`. The only exception is active audio streaming sessions.
+
+Key facts:
+- Works in Simulator (uses macOS networking stack) but **fails 100% on real hardware**.
+- Every major WebSocket library (Pusher, Starscream, Socket.IO, Firebase) dropped WatchOS support.
+- WatchOS 10 and 11 did **not** lift this restriction.
+- Standard HTTP (`URLSessionDataTask`) works reliably on WatchOS.
+
+## 3. Comparison Table
+
+| Approach | Server push? | Entity filtering? | Delta? | WatchOS? |
+|---|---|---|---|---|
+| **Integration (current)** | Yes (long-poll) | Yes (server) | Yes | **Yes** |
+| WS `subscribe_entities` | Yes | Yes | Yes (compressed) | **NO — blocked** |
+| SSE `/api/stream` | Yes | **NO** | No | Uncertain (untested) |
+| `POST /api/template` | No (poll) | Yes (template) | Yes (timestamps) | Yes |
+| History API | No (poll) | Yes (server) | Yes (time-based) | Yes |
+
+## 4. Potential HA Core PR
+
+### Option A: Small PR — Add entity filtering to `/api/stream`
+- Add `entity_id` query parameter to the existing SSE endpoint (~10 lines of code).
+- **Acceptance chance: ~20%** — the endpoint is semi-deprecated and not officially documented.
+
+### Option B: Better PR — New SSE endpoint
+- New `GET /api/states/stream` SSE endpoint mirroring `subscribe_entities` behavior with `entity_ids` + compressed deltas over HTTP.
+- **Acceptance chance: ~30-40%** — solves a real gap in the API surface.
+
+### Key argument for either PR
+> "Apple Watch and embedded devices cannot use WebSocket due to platform restrictions. There is no HTTP-based alternative for real-time entity state streaming."
+
+### Precedent
+The `entity_ids` parameter was added to the WebSocket `subscribe_entities` command specifically for the Android Companion app's performance needs. A similar motivation exists here for HTTP-based clients.
+
+## 5. Conclusion
+
+The integration provides unique value that cannot be fully replicated with built-in HA APIs:
+
+1. **HTTP long-poll** — works on WatchOS (unlike WebSocket)
+2. **Server-side entity filtering** — reduces bandwidth (unlike SSE `/api/stream`)
+3. **Delta-only payloads** — minimizes transfer size
+4. **WatchOS compatibility** — the combination of the above three
+
+The closest alternative would be polling `POST /api/template` with timestamp-based delta detection, but this trades real-time push for polling latency and puts template logic burden on the client.
+
+A successful HA Core PR adding an HTTP-based streaming endpoint with entity filtering would be the only path to eliminating the need for this integration.


### PR DESCRIPTION
## Summary
- Rewrote README for App Store launch: simplified setup instructions, removed internal API reference, and focused on the user-facing experience
- Streamlined release notes template to match simplified integration surface
- Added Claude Code release automation skill and future ideas research doc
- Bumped version to 0.7.4

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm HACS detects the new version after release
- [ ] Spot-check that no internal API details leaked into the public README

🤖 Generated with [Claude Code](https://claude.com/claude-code)