### PR TITLE
Release v0.7.6: Use modern HA camera API

### DIFF
--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["Pillow>=10.0"],
-  "version": "0.7.5"
+  "version": "0.7.6"
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `hass.components.camera.async_get_image` with direct `async_get_image` import from `homeassistant.components.camera`
- Add explicit `timeout=5` parameter to frame capture
- Add `HomeAssistantError` handling for camera unavailability with debug logging
- Bump version to 0.7.6

## Test plan
- [ ] Verify camera stream loads on wrist assistant watch UI
- [ ] Confirm stream recovers gracefully when camera entity is temporarily unavailable
- [ ] Check no deprecation warnings in HA logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)