### PR TITLE
Allow dynamic width update on camera streams (v0.7.7)

### DIFF
--- a/custom_components/wrist_assistant/manifest.json
+++ b/custom_components/wrist_assistant/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/NylonDiamond/homeassistant-wrist-assistant/issues",
   "requirements": ["Pillow>=10.0"],
-  "version": "0.7.6"
+  "version": "0.7.7"
 }


### PR DESCRIPTION
## Summary
- Rename `update_viewport` to `update_session` to reflect broader responsibility
- Accept optional `width` parameter on the viewport/session update endpoint, allowing watch clients to resize the stream without restarting it
- Viewport fields (`x`, `y`, `w`, `h`) are now optional — you can send just `width`, just viewport, or both
- Bump version to v0.7.7

## Test plan
- [ ] Start a camera stream session and verify existing viewport updates still work
- [ ] Send a POST with only `width` and confirm the stream resizes without affecting the viewport crop
- [ ] Send a POST with both viewport and width and confirm both update
- [ ] Confirm HACS detects the new version after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)